### PR TITLE
Use `os.RemoveAll` instead of `os.Remove` to clean up pidfile

### DIFF
--- a/src/bpm/commands/root.go
+++ b/src/bpm/commands/root.go
@@ -194,7 +194,7 @@ func newRuncLifecycle() (*lifecycle.RuncLifecycle, error) {
 		userFinder,
 		lifecycle.NewCommandRunner(),
 		clock,
-		os.Remove,
+		os.RemoveAll,
 	), nil
 }
 

--- a/src/bpm/integration/start_test.go
+++ b/src/bpm/integration/start_test.go
@@ -299,6 +299,25 @@ var _ = Describe("start", func() {
 			state := runcState(runcRoot, containerID)
 			Expect(state.Status).To(Equal("running"))
 		})
+
+		Context("and the pid file does not exist", func() {
+			JustBeforeEach(func() {
+				err := os.RemoveAll(filepath.Join(boshRoot, "sys", "run", "bpm", job, fmt.Sprintf("%s.pid", job)))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("`bpm start` cleans up the associated container and artifacts and starts it", func() {
+				command = exec.Command(bpmPath, "start", job)
+				command.Env = append(command.Env, fmt.Sprintf("BPM_BOSH_ROOT=%s", boshRoot))
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(0))
+
+				state := runcState(runcRoot, containerID)
+				Expect(state.Status).To(Equal("running"))
+			})
+		})
 	})
 
 	Context("when the process is not defined in the bpm config", func() {


### PR DESCRIPTION
This change uses `RemoveAll` to forcibly delete the pidfile when
cleaning up a failed bpm process.

After a BOSH vm is rebooted, the contents of `/var/vcap/sys/run` are not
present. At the moment, bpm will fail to clean up the pidfile associated
with the failed process. This change fixes an error that occurs when
starting up a failed container after a reboot.