### PR TITLE
Shared volumes

### DIFF
--- a/packages/bpm/spec
+++ b/packages/bpm/spec
@@ -13,12 +13,14 @@ files:
   - bpm/config/*.go # gosub
   - bpm/exitstatus/*.go # gosub
   - bpm/jobid/*.go # gosub
+  - bpm/locksmith/*.go # gosub
   - bpm/models/*.go # gosub
   - bpm/presenters/*.go # gosub
   - bpm/runc/adapter/*.go # gosub
   - bpm/runc/client/*.go # gosub
   - bpm/runc/lifecycle/*.go # gosub
   - bpm/runc/specbuilder/*.go # gosub
+  - bpm/sharedvolume/*.go # gosub
   - bpm/sysfeat/*.go # gosub
   - bpm/usertools/*.go # gosub
   - bpm/vendor/code.cloudfoundry.org/bytefmt/*.go # gosub

--- a/src/bpm/commands/root.go
+++ b/src/bpm/commands/root.go
@@ -29,9 +29,11 @@ import (
 
 	"bpm/cgroups"
 	"bpm/config"
+	"bpm/locksmith"
 	"bpm/runc/adapter"
 	"bpm/runc/client"
 	"bpm/runc/lifecycle"
+	"bpm/sharedvolume"
 	"bpm/sysfeat"
 	"bpm/usertools"
 )
@@ -183,7 +185,8 @@ func newRuncLifecycle() (*lifecycle.RuncLifecycle, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch system features: %q", err)
 	}
-	runcAdapter := adapter.NewRuncAdapter(*features, filepath.Glob)
+	sharedVolume := sharedvolume.NewFactory(locksmith.NewExclusiveFileSystem(config.LocksDir(bosh.Root())))
+	runcAdapter := adapter.NewRuncAdapter(*features, filepath.Glob, sharedVolume)
 	clock := clock.NewClock()
 
 	return lifecycle.NewRuncLifecycle(

--- a/src/bpm/config/bpm_config.go
+++ b/src/bpm/config/bpm_config.go
@@ -34,6 +34,10 @@ func RuncRoot(boshRoot string) string {
 	return filepath.Join(boshRoot, "data", "bpm", "runc")
 }
 
+func LocksDir(boshRoot string) string {
+	return filepath.Join(boshRoot, "data", "bpm", "locks")
+}
+
 type BPMConfig struct {
 	boshRoot string
 	jobName  string

--- a/src/bpm/locksmith/filesystem.go
+++ b/src/bpm/locksmith/filesystem.go
@@ -1,0 +1,55 @@
+package locksmith
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"code.cloudfoundry.org/lager"
+	"golang.org/x/sys/unix"
+)
+
+type FileSystem struct {
+	locksDir string
+	lockType int
+}
+
+func NewExclusiveFileSystem(locksDir string) *FileSystem {
+	return &FileSystem{
+		locksDir: locksDir,
+		lockType: unix.LOCK_EX,
+	}
+}
+
+var FlockSyscall = unix.Flock
+
+func (l *FileSystem) Lock(logger lager.Logger, key string) (*os.File, error) {
+	if err := os.MkdirAll(l.locksDir, 0755); err != nil {
+		return nil, err
+	}
+	key = strings.Replace(key, "/", "", -1)
+	lockFile, err := os.OpenFile(l.path(key), os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("creating lock file for key `%s`: %v", key, err)
+	}
+
+	fd := int(lockFile.Fd())
+	logger.Info("acuiring-lock", lager.Data{"key": key, "lockfile": lockFile.Name()})
+	if err := FlockSyscall(fd, l.lockType); err != nil {
+		return nil, err
+	}
+
+	return lockFile, nil
+}
+
+func (l *FileSystem) Unlock(logger lager.Logger, lockFile *os.File) error {
+	logger.Info("releasing-lock", lager.Data{"lockfile": lockFile.Name()})
+	defer lockFile.Close()
+	fd := int(lockFile.Fd())
+	return FlockSyscall(fd, unix.LOCK_UN)
+}
+
+func (l *FileSystem) path(key string) string {
+	return filepath.Join(l.locksDir, key+".lock")
+}

--- a/src/bpm/runc/lifecycle/lifecycle.go
+++ b/src/bpm/runc/lifecycle/lifecycle.go
@@ -67,7 +67,7 @@ type CommandRunner interface {
 //go:generate counterfeiter . RuncAdapter
 
 type RuncAdapter interface {
-	CreateJobPrerequisites(bpmCfg *config.BPMConfig, procCfg *config.ProcessConfig, user specs.User) (*os.File, *os.File, error)
+	CreateJobPrerequisites(logger lager.Logger, bpmCfg *config.BPMConfig, procCfg *config.ProcessConfig, user specs.User) (*os.File, *os.File, error)
 	BuildSpec(logger lager.Logger, bpmCfg *config.BPMConfig, procCfg *config.ProcessConfig, user specs.User) (specs.Spec, error)
 }
 
@@ -166,7 +166,7 @@ func (j *RuncLifecycle) setupProcess(logger lager.Logger, bpmCfg *config.BPMConf
 	}
 
 	logger.Info("creating-job-prerequisites")
-	stdout, stderr, err := j.runcAdapter.CreateJobPrerequisites(bpmCfg, procCfg, user)
+	stdout, stderr, err := j.runcAdapter.CreateJobPrerequisites(logger, bpmCfg, procCfg, user)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create system files: %s", err.Error())
 	}

--- a/src/bpm/sharedvolume/shared_volume.go
+++ b/src/bpm/sharedvolume/shared_volume.go
@@ -1,0 +1,72 @@
+package sharedvolume
+
+import (
+	"fmt"
+	"os"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/opencontainers/runc/libcontainer/mount"
+	"golang.org/x/sys/unix"
+)
+
+type Locksmith interface {
+	Lock(logger lager.Logger, key string) (*os.File, error)
+	Unlock(logger lager.Logger, lockFile *os.File) error
+}
+
+type Factory struct {
+	locksmith Locksmith
+}
+
+func NewFactory(locksmith Locksmith) *Factory {
+	return &Factory{locksmith: locksmith}
+}
+
+func (f *Factory) Create(logger lager.Logger, path string) error {
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return fmt.Errorf("failed to mkdir %q: %v", path, err)
+	}
+
+	if err := f.ensureMounted(logger, path); err != nil {
+		return err
+	}
+
+	if err := makeSharedMount(logger, path); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *Factory) ensureMounted(logger lager.Logger, path string) error {
+	lock, err := f.locksmith.Lock(logger, path)
+	if err != nil {
+		return err
+	}
+	defer f.locksmith.Unlock(logger, lock)
+
+	mounted, err := mount.Mounted(path)
+	if err != nil {
+		return fmt.Errorf("failed to check whether %q is already mounted: %v", path, err)
+	}
+	if mounted {
+		logger.Info("already-mounted", lager.Data{"path": path})
+		return nil
+	}
+
+	logger.Info("bind-mounting", lager.Data{"path": path})
+	if err := unix.Mount(path, path, "none", unix.MS_BIND, ""); err != nil {
+		return fmt.Errorf("failed to bind mount %q: %v", path, err)
+	}
+
+	return nil
+}
+
+func makeSharedMount(logger lager.Logger, path string) error {
+	logger.Info("making-shared-mount", lager.Data{"path": path})
+	if err := unix.Mount("", path, "", unix.MS_SHARED, ""); err != nil {
+		return fmt.Errorf("failed to make mount %q shared: %v", path, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
* introduce `shared_bpm_volumes` bpm.yml config property
* when the bpm job starts it should check whether the volume is mounted.
If not, bpm should create the volume dir, bind mount it to itself, and
make it shared.

We would really like to get your feedback on this new functionality. You can find more context in the [slack thread](https://cloudfoundry.slack.com/archives/C7A0K6NMU/p1555934755000600) that we started a few days ago. 

Co-authored-by: Danail Branekov <danailster@gmail.com>