### PR TITLE
delete broken runc state after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.8
+
+* cleanup broken runc state after restart
+
 # v1.1.7
 
 * update runc to v1.0.0-rc10

--- a/src/bpm/commands/root.go
+++ b/src/bpm/commands/root.go
@@ -216,8 +216,9 @@ func isRunningSystemd() bool {
 }
 
 // Occasionally RunC can get in an inconsistent state after a restart where
-// it's internal state.json file is truncated. RunC is unable to get out of
-// this state without some intervention. This is that intervention.
+// it's internal state.json file is truncated or missing but the parent
+// directory still exists. RunC is unable to get out of this state without some
+// intervention. This is that intervention.
 func forceCleanupBrokenRuncState(logger lager.Logger, runcLifecycle *lifecycle.RuncLifecycle) error {
 	// We compute this here rather than adding a new function to the
 	// configuration object to try and contain this hack to one place.

--- a/src/bpm/commands/start.go
+++ b/src/bpm/commands/start.go
@@ -104,6 +104,11 @@ func start(cmd *cobra.Command, _ []string) error {
 	default:
 		if err := runcLifecycle.StartProcess(logger, bpmCfg, procCfg); err != nil {
 			logger.Error("failed-to-start", err)
+
+			if cerr := forceCleanupBrokenRuncState(logger, runcLifecycle); cerr != nil {
+				logger.Error("failed-cleaning-up-broken-job", cerr)
+			}
+
 			return fmt.Errorf("failed to start job-process: %s", err)
 		}
 	}


### PR DESCRIPTION
Sometimes the RunC state directory can be empty after a restart which
causes RunC to error when trying to start the same job. If the job fails
to start then we cleanup that directory so that when monit attempts to
restart the job it should succeed.

There are some open questions...

* This may have debug-ability issues by cleaning up the failed job?

* Maybe this means we should switch this directory to be on tmpfs?

Fixes #130