### PR TITLE
Update test to output better errors

### DIFF
--- a/src/bpm/acceptance/bpm_acceptance_test.go
+++ b/src/bpm/acceptance/bpm_acceptance_test.go
@@ -133,8 +133,7 @@ var _ = Describe("BpmAcceptance", func() {
 		body, err := ioutil.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(string(body)).To(ContainSubstring("0+0 records in"))
-		Expect(string(body)).To(ContainSubstring("0+0 records out"))
+		Expect(string(body)).To(Equal(""))
 	})
 
 	It("only has access to store, data, jobs, sys, and packages in /var/vcap", func() {


### PR DESCRIPTION
Previously the test assertion was using internal details for how we detect an unmasked path using `dd`, which made it hard to understand failures. Now the endpoint (which is only used for acceptance tests) will output if the path is not masked properly, giving a more human readable string.

Signed-off-by: Brian Upton <bupton@vmware.com>