### PR TITLE
Stops limiting size of /dev/shm and /dev

### DIFF
--- a/src/bpm/runc/specbuilder/specbuilder.go
+++ b/src/bpm/runc/specbuilder/specbuilder.go
@@ -61,7 +61,7 @@ func DefaultSpec() *specs.Spec {
 				Destination: "/dev",
 				Type:        "tmpfs",
 				Source:      "tmpfs",
-				Options:     []string{"nosuid", "noexec", "mode=755", "size=65536k"},
+				Options:     []string{"nosuid", "noexec", "mode=755"},
 			},
 			{
 				Destination: "/dev/pts",
@@ -73,7 +73,7 @@ func DefaultSpec() *specs.Spec {
 				Destination: "/dev/shm",
 				Type:        "tmpfs",
 				Source:      "shm",
-				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777"},
 			},
 			{
 				Destination: "/dev/mqueue",


### PR DESCRIPTION
This commit removes the 64MB size restriction on '/dev/shm'. (It also removes the same restriction on '/dev/', but that change is less important.)

Why are we doing this?

A customer of ours is attempting to use Postgres 15 in a bpm-created container, and running into frequent, show-stopping Postgres worker crashes when Postgres needs to use more than 64MB of POSIX shared memory. We asked the customer to resize '/dev/shm' to something much, much larger than 64MB and re-run their jobs. This resolved their problem, and they were able to continue on with their work.

We dug through the history of this configuration choice, and found no company-internal discussion on why this value was chosen.

We did discover that the runc v1 Container Specification document specifies that '/dev/shm' is 64MB in size (see:
<https://github.com/opencontainers/runc/blob/eddf35e5462e2a9f24d8279874a84cfc8b8453c2/libcontainer/SPEC.md#filesystem>). However, it offers no justification for this choice, and a search of the Runc 'dev' Google Groups mailing list didn't turn up any relevant conversation. So, the reasoning for this design decision remains unknown.

Because we don't know why this setting is the way it is, and because it's causing production problems for a customer of ours, we've decided to remove the /dev/shm size restriction and let the OS automatically size the device.