### PR TITLE
Add go workflow to lint src/bpm/

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,15 @@
+name: go
+on:
+  push:
+  pull_request:
+jobs:
+  lint:
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
+      with:
+        go-version-file: src/bpm/go.mod
+    - uses: golangci/golangci-lint-action@v3
+      with:
+        working-directory: src/bpm/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+# https://golangci-lint.run/usage/configuration/
+run:
+  timeout: 5m # 1m default times out on github-action runners
+
+output:
+  # Sort results by: filepath, line and column.
+  sort-results: true

--- a/src/bpm/acceptance/bpm_acceptance_test.go
+++ b/src/bpm/acceptance/bpm_acceptance_test.go
@@ -18,7 +18,7 @@ package bpm_acceptance_test
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -41,7 +41,7 @@ var _ = Describe("BpmAcceptance", func() {
 
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(body)).To(Equal("BPM is SWEET!\n"))
 	})
@@ -51,7 +51,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(body)).To(Equal("vcap\n"))
 	})
@@ -61,7 +61,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 
 		mounts := parseMounts(string(body))
@@ -108,7 +108,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 
 		mounts := parseMounts(string(body))
@@ -130,7 +130,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(string(body)).To(Equal(""))
@@ -141,7 +141,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		directories := strings.Split(strings.Trim(string(body), "\n"), "\n")
 		Expect(directories).To(ConsistOf("store", "data", "jobs", "packages", "sys"))
@@ -152,7 +152,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		directories := strings.Split(strings.Trim(string(body), "\n"), "\n")
 		Expect(directories).To(ConsistOf("test-server", "packages", "shared"))
@@ -163,7 +163,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		directories := strings.Split(strings.Trim(string(body), "\n"), "\n")
 		Expect(directories).To(ConsistOf("test-server"))
@@ -174,7 +174,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		processes := strings.Split(strings.Trim(string(body), "\n"), "\n")
 
@@ -191,7 +191,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(body)).To(ContainSubstring("/var/vcap/jobs/test-server/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:."))
 	})
@@ -204,7 +204,7 @@ var _ = Describe("BpmAcceptance", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(body)).To(ContainSubstring("/var/vcap/data/"))
 	})
@@ -217,7 +217,7 @@ var _ = Describe("BpmAcceptance", func() {
 
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(ContainSubstring("Expected success occurred"))
 		})
@@ -229,7 +229,7 @@ var _ = Describe("BpmAcceptance", func() {
 
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(ContainSubstring("Expected error occurred"))
 		})

--- a/src/bpm/acceptance/fixtures/test-server/handlers/curl.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/curl.go
@@ -17,12 +17,11 @@ package handlers
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
 func Curl(w http.ResponseWriter, r *http.Request) {
-	address, err := ioutil.ReadAll(r.Body)
+	address, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/src/bpm/acceptance/fixtures/test-server/handlers/env.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/env.go
@@ -17,13 +17,13 @@ package handlers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 )
 
 func Env(w http.ResponseWriter, r *http.Request) {
-	envKey, err := ioutil.ReadAll(r.Body)
+	envKey, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/src/bpm/acceptance/fixtures/test-server/handlers/masked_paths.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/masked_paths.go
@@ -51,7 +51,8 @@ func MaskedPaths(w http.ResponseWriter, r *http.Request) {
 		} else {
 			cmd := exec.Command("/bin/dd", fmt.Sprintf("if=%s", path))
 			output, err := cmd.CombinedOutput()
-			defer cmd.Process.Kill() // as dd could run indefinitely and cause issues with other tests...
+			// as dd could run indefinitely and cause issues with other tests...
+			defer cmd.Process.Kill() //nolint:errcheck
 
 			if err != nil {
 				readablePaths += fmt.Sprintf("Error reading path: %s\n", path)

--- a/src/bpm/acceptance/fixtures/test-server/handlers/mounts.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/mounts.go
@@ -17,12 +17,12 @@ package handlers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 )
 
 func Mounts(w http.ResponseWriter, r *http.Request) {
-	data, err := ioutil.ReadFile("/proc/mounts")
+	data, err := os.ReadFile("/proc/mounts")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/src/bpm/acceptance/fixtures/test-server/handlers/processes.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/processes.go
@@ -17,8 +17,8 @@ package handlers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 )
 
@@ -30,12 +30,12 @@ func Processes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, item := range items {
-		body, err := ioutil.ReadFile(filepath.Join(item, "cmdline"))
+		body, err := os.ReadFile(filepath.Join(item, "cmdline"))
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
-		fmt.Fprintln(w, fmt.Sprintf("%s %s", filepath.Base(item), string(body)))
+		fmt.Fprintf(w, "%s %s\n", filepath.Base(item), string(body))
 	}
 }

--- a/src/bpm/acceptance/fixtures/test-server/handlers/varvcap.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/varvcap.go
@@ -17,12 +17,12 @@ package handlers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 )
 
 func VarVcap(w http.ResponseWriter, r *http.Request) {
-	items, err := ioutil.ReadDir("/var/vcap")
+	items, err := os.ReadDir("/var/vcap")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -34,7 +34,7 @@ func VarVcap(w http.ResponseWriter, r *http.Request) {
 }
 
 func VarVcapJobs(w http.ResponseWriter, r *http.Request) {
-	items, err := ioutil.ReadDir("/var/vcap/jobs")
+	items, err := os.ReadDir("/var/vcap/jobs")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -46,7 +46,7 @@ func VarVcapJobs(w http.ResponseWriter, r *http.Request) {
 }
 
 func VarVcapData(w http.ResponseWriter, r *http.Request) {
-	items, err := ioutil.ReadDir("/var/vcap/data")
+	items, err := os.ReadDir("/var/vcap/data")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/src/bpm/bosh/env.go
+++ b/src/bpm/bosh/env.go
@@ -16,7 +16,7 @@
 package bosh
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -43,7 +43,7 @@ func NewEnv(root string) *Env {
 func (e *Env) JobNames() []string {
 	var jobs []string
 
-	fileInfos, err := ioutil.ReadDir(filepath.Join(e.root, "jobs"))
+	fileInfos, err := os.ReadDir(filepath.Join(e.root, "jobs"))
 	if err != nil {
 		return jobs
 	}

--- a/src/bpm/bosh/env_test.go
+++ b/src/bpm/bosh/env_test.go
@@ -16,7 +16,6 @@
 package bosh_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -31,7 +30,7 @@ var _ = Describe("Bosh Environment", func() {
 
 	BeforeEach(func() {
 		var err error
-		root, err = ioutil.TempDir("", "bosh_test")
+		root, err = os.MkdirTemp("", "bosh_test")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/src/bpm/commands/logs.go
+++ b/src/bpm/commands/logs.go
@@ -106,7 +106,7 @@ func logsForJob(cmd *cobra.Command, _ []string) error {
 	for {
 		select {
 		case sig := <-signals: // Forward signal received by parent to child
-			tailCmd.Process.Signal(sig)
+			tailCmd.Process.Signal(sig) //nolint:errcheck
 		case err := <-errCh: // Signal parent when child dies
 			if err != nil && err.Error() != "signal: interrupt" {
 				return err

--- a/src/bpm/commands/trace.go
+++ b/src/bpm/commands/trace.go
@@ -94,7 +94,7 @@ func trace(cmd *cobra.Command, _ []string) error {
 	for {
 		select {
 		case sig := <-signals:
-			straceCmd.Process.Signal(sig)
+			straceCmd.Process.Signal(sig) //nolint:errcheck
 		case err := <-errCh:
 			if eerr, ok := err.(*exec.ExitError); ok {
 				// was the process killed by a signal?

--- a/src/bpm/commands/version.go
+++ b/src/bpm/commands/version.go
@@ -36,7 +36,7 @@ var versionCommand = &cobra.Command{
 
 func version(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
-		cmd.Usage()
+		cmd.Usage() //nolint:errcheck
 		os.Exit(1)
 	}
 

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -18,7 +18,7 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -73,7 +73,7 @@ type Unsafe struct {
 }
 
 func ParseJobConfig(configPath string) (*JobConfig, error) {
-	data, err := ioutil.ReadFile(configPath)
+	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/bpm/flock/flock_test.go
+++ b/src/bpm/flock/flock_test.go
@@ -16,7 +16,6 @@
 package flock_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -31,7 +30,7 @@ var _ = Describe("Flock", func() {
 
 	BeforeEach(func() {
 		var err error
-		tmpdir, err = ioutil.TempDir("", "flocktest")
+		tmpdir, err = os.MkdirTemp("", "flocktest")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -56,7 +55,7 @@ var _ = Describe("Flock", func() {
 
 		It("cannot be unlocked again", func() {
 			Expect(func() {
-				lock.Unlock()
+				lock.Unlock() //nolint:errcheck
 			}).Should(Panic())
 		})
 
@@ -76,7 +75,7 @@ var _ = Describe("Flock", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(func() {
-				lock.Unlock()
+				lock.Unlock() //nolint:errcheck
 			}).Should(Panic())
 		})
 

--- a/src/bpm/hostlock/hostlock_test.go
+++ b/src/bpm/hostlock/hostlock_test.go
@@ -16,7 +16,6 @@
 package hostlock_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -30,7 +29,7 @@ var _ = Describe("Hostlock", func() {
 
 	BeforeEach(func() {
 		var err error
-		tmpdir, err = ioutil.TempDir("", "hostlock_test")
+		tmpdir, err = os.MkdirTemp("", "hostlock_test")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/src/bpm/integration/capabilities_test.go
+++ b/src/bpm/integration/capabilities_test.go
@@ -18,7 +18,6 @@ package integration_test
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -51,7 +50,7 @@ var _ = Describe("capabilities", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "capabiliteis-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "capabilities-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)
@@ -70,7 +69,7 @@ var _ = Describe("capabilities", func() {
 	AfterEach(func() {
 		err := runcCommand(runcRoot, "delete", "--force", containerID).Run()
 		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "WARNING: Failed to cleanup container: %s\n", err.Error())
+			fmt.Fprintf(GinkgoWriter, "WARNING: Failed to cleanup container: %s\n", err.Error()) //nolint:errcheck
 		}
 		Expect(os.RemoveAll(boshRoot)).To(Succeed())
 	})

--- a/src/bpm/integration/integration_suite_test.go
+++ b/src/bpm/integration/integration_suite_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -66,7 +65,7 @@ var _ = SynchronizedAfterSuite(func() {}, func() {
 
 func fileContents(path string) func() string {
 	return func() string {
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		Expect(err).NotTo(HaveOccurred())
 		return string(contents)
 	}
@@ -165,7 +164,7 @@ func copyFile(dst, src string) error {
 		return err
 	}
 	if _, err := io.Copy(d, s); err != nil {
-		d.Close()
+		d.Close() //nolint:errcheck
 		return err
 	}
 	return d.Close()
@@ -194,7 +193,7 @@ func writeConfig(root, job string, cfg config.JobConfig) {
 	Expect(os.MkdirAll(configDir, 0755)).To(Succeed())
 
 	configPath := filepath.Join(configDir, "bpm.yml")
-	Expect(ioutil.WriteFile(configPath, data, 0644)).To(Succeed())
+	Expect(os.WriteFile(configPath, data, 0644)).To(Succeed())
 }
 
 func writeInvalidConfig(root, job string) {
@@ -202,7 +201,7 @@ func writeInvalidConfig(root, job string) {
 	Expect(os.MkdirAll(configDir, 0755)).To(Succeed())
 
 	configPath := filepath.Join(configDir, "bpm.yml")
-	Expect(ioutil.WriteFile(configPath, []byte("{{"), 0644)).To(Succeed())
+	Expect(os.WriteFile(configPath, []byte("{{"), 0644)).To(Succeed())
 }
 
 func startJob(root, bpmPath, j string) {

--- a/src/bpm/integration/integration_test.go
+++ b/src/bpm/integration/integration_test.go
@@ -17,7 +17,6 @@ package integration_test
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,7 +34,7 @@ var _ = Describe("bpm", func() {
 
 		BeforeEach(func() {
 			var err error
-			unPrivilegedBPMDir, err = ioutil.TempDir("", "vcap-bpm")
+			unPrivilegedBPMDir, err = os.MkdirTemp("", "vcap-bpm")
 			Expect(err).NotTo(HaveOccurred())
 
 			f, err := os.Create(filepath.Join(unPrivilegedBPMDir, "bpm"))

--- a/src/bpm/integration/list_test.go
+++ b/src/bpm/integration/list_test.go
@@ -17,7 +17,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -68,7 +67,7 @@ var _ = Describe("list", func() {
 		invalidJob = fmt.Sprintf("invalid-%s", uuid.NewV4().String())
 		unimplementedJob = fmt.Sprintf("unimplemented-%s", uuid.NewV4().String())
 
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "list-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "list-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)
@@ -97,12 +96,12 @@ var _ = Describe("list", func() {
 	AfterEach(func() {
 		err := runcCommand(runcRoot, "delete", "--force", containerID).Run()
 		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "WARNING: Failed to cleanup container: %s\n", err.Error())
+			fmt.Fprintf(GinkgoWriter, "WARNING: Failed to cleanup container: %s\n", err.Error()) //nolint:errcheck
 		}
 
 		err = runcCommand(runcRoot, "delete", "--force", failedContainerID).Run()
 		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "WARNING: Failed to cleanup container: %s\n", err.Error())
+			fmt.Fprintf(GinkgoWriter, "WARNING: Failed to cleanup container: %s\n", err.Error()) //nolint:errcheck
 		}
 		Expect(os.RemoveAll(boshRoot)).To(Succeed())
 	})

--- a/src/bpm/integration/logs_test.go
+++ b/src/bpm/integration/logs_test.go
@@ -17,7 +17,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -51,7 +50,7 @@ var _ = Describe("logs", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "logs-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "logs-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)

--- a/src/bpm/integration/namespaces_test.go
+++ b/src/bpm/integration/namespaces_test.go
@@ -17,7 +17,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,7 +51,7 @@ var _ = Describe("start", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)

--- a/src/bpm/integration/pid_test.go
+++ b/src/bpm/integration/pid_test.go
@@ -17,7 +17,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -50,7 +49,7 @@ var _ = Describe("pid", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "pid-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "pid-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)

--- a/src/bpm/integration/privileged_test.go
+++ b/src/bpm/integration/privileged_test.go
@@ -17,7 +17,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,7 +48,7 @@ var _ = Describe("privileged containers", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)

--- a/src/bpm/integration/resource_limits_test.go
+++ b/src/bpm/integration/resource_limits_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -55,7 +54,7 @@ var _ = Describe("resource limits", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "resource-limits-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "resource-limits-test")
 		Expect(err).NotTo(HaveOccurred())
 		boshEnv = bosh.NewEnv(boshRoot)
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/integration/shell_test.go
+++ b/src/bpm/integration/shell_test.go
@@ -17,7 +17,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -53,7 +52,7 @@ var _ = Describe("start", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)

--- a/src/bpm/integration/start_test.go
+++ b/src/bpm/integration/start_test.go
@@ -17,7 +17,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -60,7 +59,7 @@ var _ = Describe("start", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		boshEnv = bosh.NewEnv(boshRoot)
@@ -99,7 +98,7 @@ var _ = Describe("start", func() {
 
 		state := runcState(runcRoot, containerID)
 		Expect(state.Status).To(Equal(specs.StateRunning))
-		pidText, err := ioutil.ReadFile(pidFile)
+		pidText, err := os.ReadFile(pidFile)
 		Expect(err).NotTo(HaveOccurred())
 
 		pid, err := strconv.Atoi(string(pidText))
@@ -191,7 +190,7 @@ var _ = Describe("start", func() {
 
 			state := runcState(runcRoot, containerID)
 			Expect(state.Status).To(Equal(specs.StateRunning))
-			pidText, err := ioutil.ReadFile(pidFile)
+			pidText, err := os.ReadFile(pidFile)
 			Expect(err).NotTo(HaveOccurred())
 
 			pid, err := strconv.Atoi(string(pidText))
@@ -320,7 +319,7 @@ var _ = Describe("start", func() {
 			Expect(session).To(gexec.Exit(0))
 			Eventually(func() specs.ContainerState { return runcState(runcRoot, containerID).Status }, 20*time.Second).Should(Equal(specs.StateStopped))
 
-			err = ioutil.WriteFile(filepath.Join(runcRoot, containerID, "state.json"), nil, 0600)
+			err = os.WriteFile(filepath.Join(runcRoot, containerID, "state.json"), nil, 0600)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -411,13 +410,13 @@ var _ = Describe("start", func() {
 			Expect(os.MkdirAll(filepath.Join(boshRoot, "jobs", "job-2", "config"), 0700)).To(Succeed())
 
 			firstIndicator := filepath.Join(boshRoot, "jobs", "job-1", "config", "indicators.yml")
-			Expect(ioutil.WriteFile(firstIndicator, []byte("i am the first indicator file"), 0700)).To(Succeed())
+			Expect(os.WriteFile(firstIndicator, []byte("i am the first indicator file"), 0700)).To(Succeed())
 
 			secondIndicator := filepath.Join(boshRoot, "jobs", "job-2", "config", "indicators.yml")
-			Expect(ioutil.WriteFile(secondIndicator, []byte("i am the second indicator file"), 0700)).To(Succeed())
+			Expect(os.WriteFile(secondIndicator, []byte("i am the second indicator file"), 0700)).To(Succeed())
 
 			secret := filepath.Join(boshRoot, "jobs", "job-1", "config", "secrets.yml")
-			Expect(ioutil.WriteFile(secret, []byte("i am the secret file"), 0700)).To(Succeed())
+			Expect(os.WriteFile(secret, []byte("i am the secret file"), 0700)).To(Succeed())
 
 			cfg = newJobConfig(job, findBash(filepath.Join(boshRoot, "jobs")))
 			cfg.Processes[0].Unsafe = &config.Unsafe{

--- a/src/bpm/integration/stop_test.go
+++ b/src/bpm/integration/stop_test.go
@@ -16,12 +16,12 @@
 package integration_test
 
 import (
-	"bpm/bosh"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"bpm/bosh"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -55,7 +55,7 @@ var _ = Describe("stop", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "stop-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "stop-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		boshEnv = bosh.NewEnv(boshRoot)

--- a/src/bpm/integration/trace_test.go
+++ b/src/bpm/integration/trace_test.go
@@ -17,7 +17,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -50,7 +49,7 @@ var _ = Describe("trace", func() {
 
 		job = uuid.NewV4().String()
 		containerID = jobid.Encode(job)
-		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
+		boshRoot, err = os.MkdirTemp(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)

--- a/src/bpm/integration2/bpmsandbox/sandbox.go
+++ b/src/bpm/integration2/bpmsandbox/sandbox.go
@@ -18,7 +18,6 @@ package bpmsandbox
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,7 +39,7 @@ type Sandbox struct {
 func New(t *testing.T) *Sandbox {
 	t.Helper()
 
-	root, err := ioutil.TempDir("", "bpm_sandbox")
+	root, err := os.MkdirTemp("", "bpm_sandbox")
 	if err != nil {
 		t.Fatalf("could not create sandbox root directory: %v", err)
 	}

--- a/src/bpm/integration2/run_test.go
+++ b/src/bpm/integration2/run_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,7 +76,7 @@ func TestRun(t *testing.T) {
 		t.Errorf("stdout/stderr did not contain %q, contents: %q", sentinel, contents)
 	}
 
-	stdout, err := ioutil.ReadFile(s.Path("sys", "log", "errand", "errand.stdout.log"))
+	stdout, err := os.ReadFile(s.Path("sys", "log", "errand", "errand.stdout.log"))
 	if err != nil {
 		t.Fatalf("failed to read stdout log: %v", err)
 	}
@@ -85,7 +84,7 @@ func TestRun(t *testing.T) {
 		t.Errorf("stdout log file did not contain %q, contents: %q", sentinel, contents)
 	}
 
-	stderr, err := ioutil.ReadFile(s.Path("sys", "log", "errand", "errand.stderr.log"))
+	stderr, err := os.ReadFile(s.Path("sys", "log", "errand", "errand.stderr.log"))
 	if err != nil {
 		t.Fatalf("failed to read stderr log: %v", err)
 	}
@@ -164,7 +163,7 @@ func TestRunWithVolumeFlags(t *testing.T) {
 		t.Errorf("mount contained read only option, contents: %s", mnt.Options)
 	}
 
-	fileContents, err := ioutil.ReadFile(extraVolumeFile)
+	fileContents, err := os.ReadFile(extraVolumeFile)
 	if err != nil {
 		t.Fatalf("failed to read extra volume file: %v", err)
 	}

--- a/src/bpm/license_test.go
+++ b/src/bpm/license_test.go
@@ -16,15 +16,13 @@
 package bpm_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestLicenses(t *testing.T) {
@@ -67,7 +65,7 @@ var _ = Describe("our go source code", func() {
 				return nil
 			}
 
-			bs, err := ioutil.ReadFile(path)
+			bs, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -141,7 +141,7 @@ func (a *RuncAdapter) makeShared(volume config.Volume) error {
 	if err != nil {
 		return err
 	}
-	defer held.Unlock()
+	defer held.Unlock() //nolint:errcheck
 
 	if err := a.shareMount(volume.Path); err != nil {
 		return err

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -18,7 +18,6 @@ package adapter
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -67,7 +66,7 @@ var _ = Describe("RuncAdapter", func() {
 		user = specs.User{UID: 200, GID: 300, Username: "vcap"}
 
 		var err error
-		systemRoot, err = ioutil.TempDir("", "runc-adapter-system-files")
+		systemRoot, err = os.MkdirTemp("", "runc-adapter-system-files")
 		Expect(err).NotTo(HaveOccurred())
 		boshEnv := bosh.NewEnv(systemRoot)
 
@@ -176,7 +175,7 @@ var _ = Describe("RuncAdapter", func() {
 			var tempFilePath string
 
 			BeforeEach(func() {
-				f, err := ioutil.TempFile(systemRoot, "temp-file")
+				f, err := os.CreateTemp(systemRoot, "temp-file")
 				Expect(err).NotTo(HaveOccurred())
 				defer f.Close()
 

--- a/src/bpm/runc/client/client_test.go
+++ b/src/bpm/runc/client/client_test.go
@@ -17,7 +17,6 @@ package client_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -55,7 +54,7 @@ var _ = Describe("RuncClient", func() {
 			}
 
 			var err error
-			bundlesRoot, err = ioutil.TempDir("", "bundle-builder")
+			bundlesRoot, err = os.MkdirTemp("", "bundle-builder")
 			Expect(err).ToNot(HaveOccurred())
 
 			bundlePath = filepath.Join(bundlesRoot, "bundle")
@@ -87,7 +86,7 @@ var _ = Describe("RuncClient", func() {
 			Expect(f.Sys().(*syscall.Stat_t).Uid).To(Equal(uint32(0)))
 			Expect(f.Sys().(*syscall.Stat_t).Gid).To(Equal(uint32(0)))
 
-			infos, err := ioutil.ReadDir(bundlefs)
+			infos, err := os.ReadDir(bundlefs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(infos).To(HaveLen(0))
 		})
@@ -104,7 +103,7 @@ var _ = Describe("RuncClient", func() {
 			expectedConfigData, err := json.MarshalIndent(&jobSpec, "", "\t")
 			Expect(err).NotTo(HaveOccurred())
 
-			configData, err := ioutil.ReadFile(configPath)
+			configData, err := os.ReadFile(configPath)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(configData).To(MatchJSON(expectedConfigData))
 		})
@@ -142,7 +141,7 @@ var _ = Describe("RuncClient", func() {
 
 		BeforeEach(func() {
 			var err error
-			bundlePath, err = ioutil.TempDir("", "bundle-builder")
+			bundlePath, err = os.MkdirTemp("", "bundle-builder")
 			Expect(err).ToNot(HaveOccurred())
 
 			jobSpec := specs.Spec{
@@ -176,7 +175,7 @@ var _ = Describe("RuncClient", func() {
 
 		BeforeEach(func() {
 			var err error
-			tempDir, err = ioutil.TempDir("", "")
+			tempDir, err = os.MkdirTemp("", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			fakeRuncPath = filepath.Join(tempDir, "fakeRunc")
@@ -200,7 +199,7 @@ echo -n '[]'
 exit 0
 `)
 
-				err := ioutil.WriteFile(fakeRuncPath, contents, 0700)
+				err := os.WriteFile(fakeRuncPath, contents, 0700)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -220,7 +219,7 @@ exit 0
 
 		BeforeEach(func() {
 			var err error
-			tempDir, err = ioutil.TempDir("", "")
+			tempDir, err = os.MkdirTemp("", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			fakeRuncPath = filepath.Join(tempDir, "fakeRunc")
@@ -235,7 +234,7 @@ else
 fi
 `)
 
-			err = ioutil.WriteFile(fakeRuncPath, contents, 0700)
+			err = os.WriteFile(fakeRuncPath, contents, 0700)
 			Expect(err).NotTo(HaveOccurred())
 
 			runcClient = client.NewRuncClient(fakeRuncPath, "/path/to/things", true)
@@ -260,7 +259,7 @@ fi
 
 		BeforeEach(func() {
 			var err error
-			tempDir, err = ioutil.TempDir("", "")
+			tempDir, err = os.MkdirTemp("", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			fakeRuncPath = filepath.Join(tempDir, "fakeRunc")
@@ -280,7 +279,7 @@ echo -n '{"msg": "container does not exist"}'
 exit 1
 `)
 
-				err := ioutil.WriteFile(fakeRuncPath, contents, 0700)
+				err := os.WriteFile(fakeRuncPath, contents, 0700)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -299,7 +298,7 @@ echo '         {"msg":"container does not exist"}     '
 exit 1
 `)
 
-					err := ioutil.WriteFile(fakeRuncPath, contents, 0700)
+					err := os.WriteFile(fakeRuncPath, contents, 0700)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -319,7 +318,7 @@ echo -n 'some unrelated error'
 exit 1
 `)
 
-				err := ioutil.WriteFile(fakeRuncPath, contents, 0700)
+				err := os.WriteFile(fakeRuncPath, contents, 0700)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/src/bpm/runc/lifecycle/lifecycle_test.go
+++ b/src/bpm/runc/lifecycle/lifecycle_test.go
@@ -18,7 +18,6 @@ package lifecycle_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -92,9 +91,9 @@ var _ = Describe("RuncJobLifecycle", func() {
 		expectedUser = specs.User{Username: "vcap", UID: 300, GID: 400}
 
 		var err error
-		expectedStdout, err = ioutil.TempFile("", "runc-lifecycle-stdout")
+		expectedStdout, err = os.CreateTemp("", "runc-lifecycle-stdout")
 		Expect(err).NotTo(HaveOccurred())
-		expectedStderr, err = ioutil.TempFile("", "runc-lifecycle-stderr")
+		expectedStderr, err = os.CreateTemp("", "runc-lifecycle-stderr")
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedJobName = "example"


### PR DESCRIPTION
- Fixes most lint errors
- Adds `//nolint:` directives otherwise