### PR TITLE
cgroup setup code provides wrapped errors

### DIFF
--- a/src/bpm/commands/root.go
+++ b/src/bpm/commands/root.go
@@ -72,7 +72,7 @@ func rootPre(cmd *cobra.Command, _ []string) error {
 
 	usr, err := user.Current()
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to get current user: %s", err)
 	}
 
 	if usr.Uid != "0" && usr.Gid != "0" {
@@ -88,7 +88,11 @@ func rootPre(cmd *cobra.Command, _ []string) error {
 	locks = hostlock.NewHandle(lockDir)
 
 	if !isRunningSystemd() {
-		return cgroups.Setup()
+		err := cgroups.Setup()
+		if err != nil {
+			err = fmt.Errorf("unable to setup cgroups: %s", err)
+		}
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
this should make it easier to diagnose cgroup v2 issues

this should help in understanding how to address cgroup v1 / v2 differences which appear to be causing failures on Noble stemcells, see https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/355 