### PR TITLE
Experimental support for cgroups v2

### DIFF
--- a/src/bpm/cgroups/cgroup.go
+++ b/src/bpm/cgroups/cgroup.go
@@ -32,6 +32,10 @@ import (
 const cgroupRoot = "/sys/fs/cgroup"
 
 func Setup() error {
+	if cgroups.IsCgroup2UnifiedMode() {
+		return nil
+	}
+
 	mounts, err := mountinfo.GetMounts(mountinfo.ParentsFilter(cgroupRoot))
 	if err != nil {
 		return fmt.Errorf("unable to retrieve mounts: %s", err)


### PR DESCRIPTION
These changes do not appear to impact the behavior of `bpm` when running on an `ubuntu-jammy` based stemcell (cgroups v1). It should be safe to merge this as the behavior of the code handling cgroup-v1 has not changed.

---

### Previous context left for posterity:

Currently one test in the integration specs is failing. Unclear if this is the fault of my docker setup or if this represents an actual issue with how `runc` is being setup.

Tests can be run as follows:
```shell
# from the repo root
cd src/bpm/
./scripts/test-unit --keep-going
```

Example of the failure I'm seeing when running these tests from within the container created using `./scripts/start-docker`
```
------------------------------
• [FAILED] [0.167 seconds]
resource limits memory [It] gets OOMed when it exceeds its memory limit
/bpm/src/bpm/integration/resource_limits_test.go:116

  Timeline >>
  If this test fails, then make sure you have enabled swap accounting! Details are in the README.
  Error: failed to start job-process: exit status 1
  [FAILED] in [It] - /bpm/src/bpm/integration/resource_limits_test.go:122 @ 06/28/24 22:07:30.852
  BEGIN '/bpmtmp/resource-limits-test1115196611/sys/log/0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2/0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2.stderr.log'
  time="2024-06-28T22:07:30Z" level=warning msg="unable to get oom kill count" error="openat2 /sys/fs/cgroup/bpm-0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2/memory.events: no such file or directory"
  time="2024-06-28T22:07:30Z" level=error msg="runc run failed: unable to start container process: unable to apply cgroup configuration: cannot enter cgroupv2 \"/sys/fs/cgroup/bpm-0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2\" with domain controllers -- it is in an invalid state"
  END   '/bpmtmp/resource-limits-test1115196611/sys/log/0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2/0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2.stderr.log'
  BEGIN '/bpmtmp/resource-limits-test1115196611/sys/log/0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2/0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2.stdout.log'
  END   '/bpmtmp/resource-limits-test1115196611/sys/log/0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2/0cf7c73a-0b65-4f46-90a7-eb0bb809e6c2.stdout.log'
  << Timeline

  [FAILED] Expected
      <int>: 1
  to match exit code:
      <int>: 0
  In [It] at: /bpm/src/bpm/integration/resource_limits_test.go:122 @ 06/28/24 22:07:30.852
------------------------------
••••••••••••••••••••••••••
------------------------------
• [FAILED] [0.364 seconds]
start when a broken runc configuration is left on the system [It] `bpm start` cleans up the broken-ness and starts it
/bpm/src/bpm/integration/start_test.go:329

  Timeline >>
  Error: failed to start job-process: exit status 1
  [FAILED] in [It] - /bpm/src/bpm/integration/start_test.go:337 @ 06/28/24 22:07:31.915
  BEGIN '/bpmtmp/start-test2475062763/sys/log/e599a26c-5d89-421d-a740-04dd490c314b/e599a26c-5d89-421d-a740-04dd490c314b.stdout.log'
  en_US.UTF-8
  Logging to STDOUT
  Received a TERM signal
  END   '/bpmtmp/start-test2475062763/sys/log/e599a26c-5d89-421d-a740-04dd490c314b/e599a26c-5d89-421d-a740-04dd490c314b.stdout.log'
  BEGIN '/bpmtmp/start-test2475062763/sys/log/e599a26c-5d89-421d-a740-04dd490c314b/e599a26c-5d89-421d-a740-04dd490c314b.stderr.log'
  Logging to STDERR
  [WARN  tini (1)] Reaped zombie process with pid=8
  time="2024-06-28T22:07:31Z" level=error msg="runc run failed: unable to get cgroup PIDs: read /sys/fs/cgroup/bpm-e599a26c-5d89-421d-a740-04dd490c314b/cgroup.procs: operation not supported"
  END   '/bpmtmp/start-test2475062763/sys/log/e599a26c-5d89-421d-a740-04dd490c314b/e599a26c-5d89-421d-a740-04dd490c314b.stderr.log'
  << Timeline

  [FAILED] Expected
      <int>: 1
  to match exit code:
      <int>: 0
  In [It] at: /bpm/src/bpm/integration/start_test.go:337 @ 06/28/24 22:07:31.915
------------------------------
•••••••••••••••••••••••••••••

Summarizing 2 Failures:
  [FAIL] resource limits memory [It] gets OOMed when it exceeds its memory limit
  /bpm/src/bpm/integration/resource_limits_test.go:122
  [FAIL] start when a broken runc configuration is left on the system [It] `bpm start` cleans up the broken-ness and starts it
  /bpm/src/bpm/integration/start_test.go:337

Ran 69 of 69 Specs in 27.622 seconds
FAIL! -- 67 Passed | 2 Failed | 0 Pending | 0 Skipped
```