### PR TITLE
Use concourse dns servers in bosh subnet

### DIFF
--- a/scripts/test-acceptance
+++ b/scripts/test-acceptance
@@ -6,7 +6,15 @@ set -x
 RELEASE_PATH="$(cd "$(dirname "$0")/.." && pwd)"
 export RELEASE_PATH
 
-. start-bosh
+# get the nameservers in the concourse container formatted as a json array--we will pass these along to bosh so that it has something usable
+NAMESERVERS=$(grep "nameserver" /etc/resolv.conf | awk 'BEGIN{sep="";printf "["} {printf "%s%s", sep, $2; sep=","} END{print "]"}')
+
+pushd /usr/local/bosh-deployment
+bosh int docker/cloud-config.yml -o misc/dns.yml -v internal_dns="${NAMESERVERS}" > /tmp/cc.yml
+mv /tmp/cc.yml docker/cloud-config.yml
+popd
+
+. start-bosh -o misc/dns.yml -v internal_dns="${NAMESERVERS}"
 
 source /tmp/local-bosh/director/env
 


### PR DESCRIPTION
- tests are failing because bosh-lite vms are unable to reach the default google DNS server.
- this commit scrapes the DNS server settings from the concourse container and patches them into the bosh-deployment and cloud config when spinning up bosh lite.